### PR TITLE
Define a basic GitHubActions sanity check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,38 @@
 name: main
 on: [push]
 jobs:
-  core:
+  build-jar:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Setup JDK 8
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 8
+      - name: Create 'build' directory
+        run: mkdir -p build/src/main/java/info/jerrinot/log4shell/evilfactory
+      - name: Copy Java files
+        run: cp java/EvilFactory.java build/src/main/java/info/jerrinot/log4shell/evilfactory/
+      - name: Copy 'pom.xml' file
+        run: cp java/pom.xml build/
+      - name: Build the jar file
+        run: mvn package
+        working-directory: build
+      - name: Move the jar file to the main directory
+        run: mv build/target/evilfactory-1.0-SNAPSHOT.jar .
+      - name: Initialize git config with last commit author's data
+        run: |
+          git config --local user.email "$(git log --format='%ae' HEAD^!)"
+          git config --local user.name "$(git log --format='%an' HEAD^!)"
+      - name: Commit and push the artifact
+        run: |
+          git add -f evilfactory-1.0-SNAPSHOT.jar
+          git commit -m "Add evilfactory-1.0-SNAPSHOT.jar"
+          git push
+
+  build-go:
+    needs: build-jar
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -31,6 +62,6 @@ jobs:
 
       - name: Run 'staticcheck'
         run: staticcheck ./...
-        
+
       - name: Verify if Docker image is buildable
         run: docker build . -t log4shell

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Run 'staticcheck'
         run: staticcheck ./...
+        
+      - name: Verify if Docker image is buildable
+        run: docker build . -t log4shell

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
     name: Build with Go ${{ matrix.go-version }}
     steps:
       - uses: actions/checkout@v2.3.4
+      - run: git pull
       - name: Install Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: main
+on: [push]
+jobs:
+  core:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.17.x]
+    name: Build with Go ${{ matrix.go-version }}
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Install staticcheck
+        run: go get -u golang.org/x/tools/... && go get honnef.co/go/tools/cmd/staticcheck
+
+      - name: Run 'go vet'
+        run: go vet ./...
+
+      - name: Run 'staticcheck'
+        run: staticcheck ./...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: main
-on: [push]
+on:
+  push:
+    branches:
+      - master
 jobs:
   build-jar:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We could add automation that would generate a jar file and commit it back to the repository. Would make it a bit easier for container-skeptics to have it available out of the box. 

It'd be way easier to have a dockerized jar builder to run locally, but... I assume that if someone doesn't want to run the project inside Docker, they would probably not use the builder as well.

<img width="1254" alt="image" src="https://user-images.githubusercontent.com/2182533/145729656-964bebfe-1a3c-4092-a51a-36c718e05df5.png">
